### PR TITLE
test: add find() coverage for memory and disk btrees

### DIFF
--- a/src/utec/disk/btree.h
+++ b/src/utec/disk/btree.h
@@ -179,7 +179,25 @@ public:
     write_node(right.page_id, right);
   }
 
-  bool find(const T &value) { return false; }
+  bool find(const T &value) {
+    node root = read_node(header.root_id);
+    return find(root, value);
+  }
+
+  bool find(node &ptr, const T &value) {
+    int pos = 0;
+    while (pos < ptr.count && ptr.data[pos] < value) {
+      pos++;
+    }
+    if (pos < ptr.count && ptr.data[pos] == value) {
+      return true;
+    }
+    if (ptr.children[pos] != 0) {
+      node child = read_node(ptr.children[pos]);
+      return find(child, value);
+    }
+    return false;
+  }
 
 
   void print(std::ostream& out) {

--- a/src/utec/memory/btree.h
+++ b/src/utec/memory/btree.h
@@ -133,7 +133,19 @@ public:
     ptr->count = 1;
   }
 
-  bool find(const T &value) { return false; }
+  bool find(const T &value) { return find(root, value); }
+
+  bool find(node *ptr, const T &value) {
+    if (!ptr) return false;
+    int pos = 0;
+    while (pos < ptr->count && ptr->data[pos] < value) {
+      pos++;
+    }
+    if (pos < ptr->count && ptr->data[pos] == value) {
+      return true;
+    }
+    return find(ptr->children[pos], value);
+  }
 
   void print() {
     print(root, 0);

--- a/tests/utec/disk/btree_test.cpp
+++ b/tests/utec/disk/btree_test.cpp
@@ -73,4 +73,24 @@ TEST_F(DiskBasedBtree, Iterators) {
 //  }
 }
 
+TEST_F(DiskBasedBtree, FindExistingKeys) {
+  bool trunc_file = true;
+  std::shared_ptr<pagemanager> pm = std::make_shared<pagemanager>("btree_find.index", trunc_file);
+  btree<char, BTREE_ORDER> bt(pm);
+  std::string values = "abcdefgh";
+  for (auto c : values) {
+    bt.insert(c);
+  }
+  EXPECT_TRUE(bt.find('a'));
+  EXPECT_TRUE(bt.find('d'));
+  EXPECT_TRUE(bt.find('h'));
+}
+
+TEST_F(DiskBasedBtree, FindMissingKeys) {
+  std::shared_ptr<pagemanager> pm = std::make_shared<pagemanager>("btree_find.index");
+  btree<char, BTREE_ORDER> bt(pm);
+  EXPECT_FALSE(bt.find('z'));
+  EXPECT_FALSE(bt.find('0'));
+}
+
 

--- a/tests/utec/memory/btree_test.cpp
+++ b/tests/utec/memory/btree_test.cpp
@@ -12,7 +12,7 @@ struct MemoryBasedBtree : public ::testing::Test
 
 TEST_F(MemoryBasedBtree, TestA) {
     using namespace utec::memory;
-    
+
     btree<int> bt;
     std::string values = "zxcnmvafjdaqpirue";
     for(auto c : values) {
@@ -20,6 +20,28 @@ TEST_F(MemoryBasedBtree, TestA) {
        bt.print();
     }
     bt.print();
+}
+
+TEST_F(MemoryBasedBtree, FindExistingKeys) {
+    using namespace utec::memory;
+    btree<int> bt;
+    for (int v : {10, 20, 30, 40, 50}) {
+        bt.insert(v);
+    }
+    EXPECT_TRUE(bt.find(10));
+    EXPECT_TRUE(bt.find(30));
+    EXPECT_TRUE(bt.find(50));
+}
+
+TEST_F(MemoryBasedBtree, FindMissingKeys) {
+    using namespace utec::memory;
+    btree<int> bt;
+    for (int v : {10, 20, 30}) {
+        bt.insert(v);
+    }
+    EXPECT_FALSE(bt.find(0));
+    EXPECT_FALSE(bt.find(15));
+    EXPECT_FALSE(bt.find(99));
 }
  
  


### PR DESCRIPTION
Stack from ghstack (oldest at bottom):

* **--> [#4](https://github.com/aocsa/btree_project/pull/4) test: add find() coverage for memory and disk btrees**
* [#3](https://github.com/aocsa/btree_project/pull/3) feat(disk): implement find() for disk-backed btree
* [#2](https://github.com/aocsa/btree_project/pull/2) feat(memory): implement find() for in-memory btree

---

## What

Adds `FindExistingKeys` and `FindMissingKeys` test cases to both btree variants.
No tests existed for the `find()` path before this stack.

## Files changed

| File | Change |
|---|---|
| `tests/utec/memory/btree_test.cpp` | Add `FindExistingKeys` and `FindMissingKeys` |
| `tests/utec/disk/btree_test.cpp` | Add `FindExistingKeys` and `FindMissingKeys` |